### PR TITLE
bug: change the level sort

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -315,7 +315,7 @@ func StdInfoLogger() *log.Logger {
 func V(level int) InfoLogger { return std.V(level) }
 
 func (l *zapLogger) V(level int) InfoLogger {
-	lvl := zapcore.Level(-1 * level)
+	lvl := zapcore.Level(5 - 1*level)
 	if l.zapLogger.Core().Enabled(lvl) {
 		return &infoLogger{
 			level: lvl,


### PR DESCRIPTION
log.V(6).Info("Debug")
log.V(5).Info("Info")
log.V(4).Info("Warn")
log.V(3).Info("Error")
log.V(2).Info("Dpanic")
log.V(1).Info("Panic")
log.V(0).Info("Fatal")
log.V(-1).Info("Fatal:Level(6)")