### PR TITLE
fix(pkg/log): 修复 V 方法计算 zapcore.Level 的错误；log 下 Example 加入注释

### DIFF
--- a/pkg/log/example/example.go
+++ b/pkg/log/example/example.go
@@ -35,7 +35,7 @@ func main() {
 	opts := &log.Options{
 		Level:            "debug",
 		Format:           "console",
-		EnableColor:      true,
+		EnableColor:      true, // if you need output to local path, with EnableColor must be false.
 		DisableCaller:    true,
 		OutputPaths:      []string{"test.log", "stdout"},
 		ErrorOutputPaths: []string{"error.log"},
@@ -64,6 +64,6 @@ func main() {
 	ln.Info("Message printed with [WithName] logger")
 
 	// V level使用
-	log.V(1).Info("This is a V level message")
-	log.V(1).Infow("This is a V level message with fields", "X-Request-ID", "7a7b9f24-4cae-4b2a-9464-69088b45b904")
+	log.V(log.InfoLevel).Info("This is a V level message")
+	log.V(log.ErrorLevel).Infow("This is a V level message with fields", "X-Request-ID", "7a7b9f24-4cae-4b2a-9464-69088b45b904")
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -74,7 +74,7 @@ type Logger interface {
 	// V returns an InfoLogger value for a specific verbosity level.  A higher
 	// verbosity level means a log message is less important.  It's illegal to
 	// pass a log level less than zero.
-	V(level int) InfoLogger
+	V(level Level) InfoLogger
 	Write(p []byte) (n int, err error)
 
 	// WithValues adds some key-value pairs of context to a logger.
@@ -306,13 +306,12 @@ func StdInfoLogger() *log.Logger {
 }
 
 // V return a leveled InfoLogger.
-func V(level int) InfoLogger { return std.V(level) }
+func V(level Level) InfoLogger { return std.V(level) }
 
-func (l *zapLogger) V(level int) InfoLogger {
-	lvl := zapcore.Level(5 - 1*level)
-	if l.zapLogger.Core().Enabled(lvl) {
+func (l *zapLogger) V(level Level) InfoLogger {
+	if l.zapLogger.Core().Enabled(level) {
 		return &infoLogger{
-			level: lvl,
+			level: level,
 			log:   l.zapLogger,
 		}
 	}


### PR DESCRIPTION
修复 V 方法计算 zapcore.Level 的错误，该错误导致实际使用 V 方法直接引起 panic；
log 中 Example 加入关于 EnableColor 字段的备注说明，标明输出到本地文件不时不应启用该选项。