### PR TITLE
fix: remove gin warning message

### DIFF
--- a/internal/pkg/server/config.go
+++ b/internal/pkg/server/config.go
@@ -105,10 +105,12 @@ func (c *Config) Complete() CompletedConfig {
 
 // New returns a new instance of GenericAPIServer from the given config.
 func (c CompletedConfig) New() (*GenericAPIServer, error) {
+	// setMode before gin.New()
+	gin.SetMode(c.Mode)
+
 	s := &GenericAPIServer{
 		SecureServingInfo:   c.SecureServing,
 		InsecureServingInfo: c.InsecureServing,
-		mode:                c.Mode,
 		healthz:             c.Healthz,
 		enableMetrics:       c.EnableMetrics,
 		enableProfiling:     c.EnableProfiling,

--- a/internal/pkg/server/genericapiserver.go
+++ b/internal/pkg/server/genericapiserver.go
@@ -27,7 +27,6 @@ import (
 // type GenericAPIServer gin.Engine.
 type GenericAPIServer struct {
 	middlewares []string
-	mode        string
 	// SecureServingInfo holds configuration of the TLS server.
 	SecureServingInfo *SecureServingInfo
 
@@ -83,7 +82,6 @@ func (s *GenericAPIServer) InstallAPIs() {
 
 // Setup do some setup work for gin engine.
 func (s *GenericAPIServer) Setup() {
-	gin.SetMode(s.mode)
 	gin.DebugPrintRouteFunc = func(httpMethod, absolutePath, handlerName string, nuHandlers int) {
 		log.Infof("%-6s %-s --> %s (%d handlers)", httpMethod, absolutePath, handlerName, nuHandlers)
 	}


### PR DESCRIPTION
gin.SetMode函数应在gin.New函数前执行，否则会有警告信息