### PR TITLE
fix: to be compatible with MacOS

### DIFF
--- a/scripts/make-rules/common.mk
+++ b/scripts/make-rules/common.mk
@@ -64,7 +64,7 @@ endif
 
 # Linux command settings
 FIND := find . ! -path './third_party/*' ! -path './vendor/*'
-XARGS := xargs --no-run-if-empty
+XARGS := xargs -r
 
 # Makefile settings
 ifndef V


### PR DESCRIPTION
since there is no --no-run-if-empty option in xargs command of MacOS.