### PR TITLE
fix(chore): coscli cp usage

### DIFF
--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -106,8 +106,8 @@ function iam::release::updload_tarballs() {
   for file in $(ls ${RELEASE_TARS}/*)
   do
     if [ "${COSTOOL}" == "coscli" ];then
-      coscli cp "${file}" "cos://${BUCKET}/${COS_RELEASE_DIR}/${IAM_GIT_VERSION}/"
-      coscli cp "${file}" "cos://${BUCKET}/${COS_RELEASE_DIR}/latest/"
+      coscli cp "${file}" "cos://${BUCKET}/${COS_RELEASE_DIR}/${IAM_GIT_VERSION}/${file##*/}"
+      coscli cp "${file}" "cos://${BUCKET}/${COS_RELEASE_DIR}/latest/${file##*/}"
     else
       coscmd upload  "${file}" "${COS_RELEASE_DIR}/${IAM_GIT_VERSION}/"
       coscmd upload  "${file}" "${COS_RELEASE_DIR}/latest/"


### PR DESCRIPTION
when `make release` use coscli to upload file, we should use it like this

```
$ coscli -v
coscli version v0.10.2-beta

$ coscli cp --help
Upload, download or copy objects

Format:
  ./coscli cp <source_path> <destination_path> [flags]

Example:
  Upload:
    ./coscli cp ~/example.txt cos://examplebucket/example.txt
```

so, fix `coscli cp` related usage.

