### PR TITLE
feat(apiserver): use mysql options to create mysql client instance

### DIFF
--- a/internal/apiserver/router.go
+++ b/internal/apiserver/router.go
@@ -12,7 +12,7 @@ import (
 	"github.com/marmotedu/iam/internal/apiserver/controller/v1/policy"
 	"github.com/marmotedu/iam/internal/apiserver/controller/v1/secret"
 	"github.com/marmotedu/iam/internal/apiserver/controller/v1/user"
-	"github.com/marmotedu/iam/internal/apiserver/store/mysql"
+	"github.com/marmotedu/iam/internal/apiserver/store"
 	"github.com/marmotedu/iam/internal/pkg/code"
 	"github.com/marmotedu/iam/internal/pkg/middleware"
 	"github.com/marmotedu/iam/internal/pkg/middleware/auth"
@@ -21,15 +21,11 @@ import (
 	_ "github.com/marmotedu/iam/pkg/validator"
 )
 
-func initRouter(g *gin.Engine) {
-	installMiddleware(g)
-	installController(g)
+func (s *apiServer) initRouter(storeIns store.Factory) {
+	installController(s.genericAPIServer.Engine, storeIns)
 }
 
-func installMiddleware(g *gin.Engine) {
-}
-
-func installController(g *gin.Engine) *gin.Engine {
+func installController(g *gin.Engine, storeIns store.Factory) *gin.Engine {
 	// Middlewares.
 	jwtStrategy, _ := newJWTAuth().(auth.JWTStrategy)
 	g.POST("/login", jwtStrategy.LoginHandler)
@@ -43,7 +39,6 @@ func installController(g *gin.Engine) *gin.Engine {
 	})
 
 	// v1 handlers, requiring authentication
-	storeIns, _ := mysql.GetMySQLFactoryOr(nil)
 	v1 := g.Group("/v1")
 	{
 		// user RESTful resource

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -28,6 +28,7 @@ import (
 type apiServer struct {
 	gs               *shutdown.GracefulShutdown
 	redisOptions     *genericoptions.RedisOptions
+	mysqlOptions     *genericoptions.MySQLOptions
 	gRPCAPIServer    *grpcAPIServer
 	genericAPIServer *genericapiserver.GenericAPIServer
 }
@@ -71,6 +72,7 @@ func createAPIServer(cfg *config.Config) (*apiServer, error) {
 	server := &apiServer{
 		gs:               gs,
 		redisOptions:     cfg.RedisOptions,
+		mysqlOptions:     cfg.MySQLOptions,
 		genericAPIServer: genericServer,
 		gRPCAPIServer:    extraServer,
 	}
@@ -79,7 +81,9 @@ func createAPIServer(cfg *config.Config) (*apiServer, error) {
 }
 
 func (s *apiServer) PrepareRun() preparedAPIServer {
-	initRouter(s.genericAPIServer.Engine)
+	// todo(ydx): should handle error correctly
+	storeIns, _ := mysql.GetMySQLFactoryOr(s.mysqlOptions)
+	s.initRouter(storeIns)
 
 	s.initRedisStore()
 


### PR DESCRIPTION
when `installController`, iam-apiserver create mysql instance.

```
storeIns, _ := mysql.GetMySQLFactoryOr(nil)
```

I think we should pass in a `store.Factory` with options.